### PR TITLE
Brings library up to date with Crystal 1.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.deps/
-/libs/
+/lib
 .crystal/
 
 

--- a/spec/cltk/parser_msgpack_spec.cr
+++ b/spec/cltk/parser_msgpack_spec.cr
@@ -9,7 +9,7 @@ class ArrayCalc2 < CLTK::Parser
     clause("PLS e e") { |args| args = args.as(Array); args[1].as(Int32) + args[2].as(Int32) }
     clause("SUB e e") { |args| args = args.as(Array); args[1].as(Int32) - args[2].as(Int32) }
     clause("MUL e e") { |args| args = args.as(Array); args[1].as(Int32) * args[2].as(Int32) }
-    clause("DIV e e") { |args| args = args.as(Array); args[1].as(Int32) / args[2].as(Int32) }
+    clause("DIV e e") { |args| args = args.as(Array); args[1].as(Int32) // args[2].as(Int32) }
     nil
   end
 

--- a/spec/cltk/parser_spec.cr
+++ b/spec/cltk/parser_spec.cr
@@ -77,7 +77,7 @@ class AmbiguousParser < CLTK::Parser
     clause("e PLS e") { |e0, op, e1 | e0.as(Int32) + e1.as(Int32) }
     clause("e SUB e") { |e0, op, e1 | e0.as(Int32) - e1.as(Int32) }
     clause("e MUL e") { |e0, op, e1 | e0.as(Int32) * e1.as(Int32) }
-    clause("e DIV e") { |e0, op, e1 | e0.as(Int32) / e1.as(Int32) }
+    clause("e DIV e") { |e0, op, e1 | e0.as(Int32) // e1.as(Int32) }
   end
 
   finalize
@@ -92,7 +92,7 @@ class ArrayCalc < CLTK::Parser
     clause("PLS e e") { |args| args = args.as(Array); args[1].as(Int32) + args[2].as(Int32) }
     clause("SUB e e") { |args| args = args.as(Array); args[1].as(Int32) - args[2].as(Int32) }
     clause("MUL e e") { |args| args = args.as(Array); args[1].as(Int32) * args[2].as(Int32) }
-    clause("DIV e e") { |args| args = args.as(Array); args[1].as(Int32) / args[2].as(Int32) }
+    clause("DIV e e") { |args| args = args.as(Array); args[1].as(Int32) // args[2].as(Int32) }
     nil
   end
 
@@ -218,7 +218,7 @@ class ErrorCalc < CLTK::Parser
     clause("e PLS e") { |e0, op, e1| e0.as(Int32) + e1.as(Int32) }
     clause("e SUB e") { |e0, op, e1| e0.as(Int32) - e1.as(Int32) }
     clause("e MUL e") { |e0, op, e1| e0.as(Int32) * e1.as(Int32) }
-    clause("e DIV e") { |e0, op, e1| e0.as(Int32) / e1.as(Int32) }
+    clause("e DIV e") { |e0, op, e1| e0.as(Int32) // e1.as(Int32) }
     clause("e PLS ERROR e") do |e0, op, ts, e1|
       error(ts);
       e0.as(Int32) + e1.as(Int32)
@@ -275,7 +275,7 @@ class RotatingCalc < CLTK::Parser
       ->(a : Int32, b : Int32) { a + b }, # +
       ->(a : Int32, b : Int32) { a - b }, # -
       ->(a : Int32, b : Int32) { a * b }, # *
-      ->(a : Int32, b : Int32) { a / b }  # /
+      ->(a : Int32, b : Int32) { a // b }  # /
     ]
 
     def get_op(orig_op)

--- a/src/cltk/cfg.cr
+++ b/src/cltk/cfg.cr
@@ -264,7 +264,7 @@ module CLTK
       production
     end
 
-    def callback(&callback: Symbol, Symbol, Production, Array(Int32)-> Nil)
+    def callback(&callback : Symbol, Symbol, Production, Array(Int32)-> Nil)
       @callback = callback
       nil
     end

--- a/src/cltk/lexer/environment.cr
+++ b/src/cltk/lexer/environment.cr
@@ -17,8 +17,8 @@ module CLTK
       # @param [Symbol]	start_state	Lexer's start state.
       # @param [Match]	match		Match object for matching text.
 
-      @state: Array(Symbol)
-      @match: Regex::MatchData?
+      @state : Array(Symbol)
+      @match : Regex::MatchData?
 
       def match
         @match.as(Regex::MatchData)

--- a/src/cltk/parser.cr
+++ b/src/cltk/parser.cr
@@ -244,11 +244,11 @@ module CLTK
     end
 
     # Shorthands for defining productions and clauses
-    def self.c(expression, precedence = nil, arg_type = @@default_arg_type, &action: Array(Type), Environment -> _)
+    def self.c(expression, precedence = nil, arg_type = @@default_arg_type, &action : Array(Type), Environment -> _)
       self.clause(expression, precedence, arg_type, &action)
     end
 
-    def self.p(symbol, expression = nil, precedence = nil, arg_type = @@default_arg_type, &action: Array(Type), Environment -> _)
+    def self.p(symbol, expression = nil, precedence = nil, arg_type = @@default_arg_type, &action : Array(Type), Environment -> _)
       self.production(symbol, expression, precedence, arg_type, &action)
     end
 
@@ -824,7 +824,7 @@ module CLTK
     # @param [Proc]    proc  Code to execute when the block is seen
     #
     # @return [void]
-    def self.token_hook(sym, &proc: Proc(Environment, Nil))
+    def self.token_hook(sym, &proc : Proc(Environment, Nil))
       if CFG.is_terminal?(sym)
 	@@token_hooks[sym.to_s] << proc
       else

--- a/src/cltk/parser/state.cr
+++ b/src/cltk/parser/state.cr
@@ -13,7 +13,7 @@ module CLTK
       getter :actions
 
       @id = -1
-      @actions: Hash(String, Array(CLTK::Parser::Action))
+      @actions : Hash(String, Array(CLTK::Parser::Action))
 
       def initialize(@id : Int32, @actions : Hash(String, Array(CLTK::Parser::Action)), @items : Array(CFG::Item)); end
       # Instantiate a new State object.

--- a/src/cltk/parsers/infix_calc.cr
+++ b/src/cltk/parsers/infix_calc.cr
@@ -30,7 +30,7 @@ module CLTK
 	clause("e PLS e") { |e0, op, e1| e0.as(Int32) + e1.as(Int32) }
 	clause("e SUB e") { |e0, op, e1| e0.as(Int32) - e1.as(Int32) }
 	clause("e MUL e") { |e0, op, e1| e0.as(Int32) * e1.as(Int32) }
-	clause("e DIV e") { |e0, op, e1| e0.as(Int32) / e1.as(Int32) }
+	clause("e DIV e") { |e0, op, e1| e0.as(Int32) // e1.as(Int32) }
       end
 
       finalize

--- a/src/cltk/parsers/postfix_calc.cr
+++ b/src/cltk/parsers/postfix_calc.cr
@@ -22,7 +22,7 @@ module CLTK
 	clause("e e PLS") { |e0, e1, op| e0.as(Int32) + e1.as(Int32) }
 	clause("e e SUB") { |e0, e1, op| e0.as(Int32) - e1.as(Int32) }
 	clause("e e MUL") { |e0, e1, op| e0.as(Int32) * e1.as(Int32) }
-	clause("e e DIV") { |e0, e1, op| e0.as(Int32) / e1.as(Int32) }
+	clause("e e DIV") { |e0, e1, op| e0.as(Int32) // e1.as(Int32) }
         nil
       end
 

--- a/src/cltk/parsers/prefix_calc.cr
+++ b/src/cltk/parsers/prefix_calc.cr
@@ -22,7 +22,7 @@ module CLTK
 	clause("PLS e e") { |op, e0, e1| e0.as(Int32) + e1.as(Int32) }
 	clause("SUB e e") { |op, e0, e1| e0.as(Int32) - e1.as(Int32) }
 	clause("MUL e e") { |op, e0, e1| e0.as(Int32) * e1.as(Int32) }
-	clause("DIV e e") { |op, e0, e1| e0.as(Int32) / e1.as(Int32) }
+	clause("DIV e e") { |op, e0, e1| e0.as(Int32) // e1.as(Int32) }
         nil
       end
 

--- a/src/cltk/scanner.cr
+++ b/src/cltk/scanner.cr
@@ -274,7 +274,7 @@ module CLTK
     # wrap the given block to be yielded in an Environment
     private macro block_to_proc(&block)
       {%unless block.is_a? Nop %}
-        ProcType.new do |{{block.args.first}}, env|
+        ProcType.new do |{{block.args.first || "_".id }}, env|
           env.yield_with_self do
             {{block.body}}
           end


### PR DESCRIPTION
Hi @ziprandom 

This commit modifies the specs based on https://github.com/ziprandom/cltk/pull/7 as well as updates
usage of type expressions to be compatible with newer Crystal

If/after crystal-dfa is brought up to date with https://github.com/ziprandom/crystal-dfa/pull/6, the specs in this MR should start passing.

Thanks!